### PR TITLE
Fix typo in test name

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -131,8 +131,8 @@ The editor JOE creates a file DEADJOE on crashes, which contains content of the 
 Similar to backupfiles.
 
 
-sql_dumps
----------
+sql_dump
+--------
 
 This checks for common names of SQL database dumps. These can lead to massive database leaks.
 


### PR DESCRIPTION
"sql_dumps" should be "sql_dump" according to the code. 

```
$ snallygaster -t sql_dumps localhost
Test sql_dumps does not exist
$ snallygaster -t sql_dump localhost
$
```