### PR TITLE
Wordpress test

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -132,7 +132,7 @@ Similar to backupfiles.
 
 
 sql_dump
---------
+---------
 
 This checks for common names of SQL database dumps. These can lead to massive database leaks.
 
@@ -262,3 +262,9 @@ drupal
 ------
 
 Checks for the presence of the Drupal CMS and outputs the version.
+
+
+wordpress
+---------
+
+Checks for the presence of the Wordpress CMS and outputs the version.

--- a/TESTS.md
+++ b/TESTS.md
@@ -132,7 +132,7 @@ Similar to backupfiles.
 
 
 sql_dump
----------
+--------
 
 This checks for common names of SQL database dumps. These can lead to massive database leaks.
 

--- a/snallygaster
+++ b/snallygaster
@@ -608,6 +608,20 @@ def test_drupal(url):
         pass
 
 
+@INFO
+def test_wordpress(url):
+    version_pattern = r"href=.*ver=\d+\.\d+\.\d+"
+    r = fetcher(url + "/wp-login.php")
+    try:
+        if r != "":
+            match = re.search(version_pattern, r)
+            if match:
+                version = match.group().split("ver=")[1]
+                pout("wordpress", url, version)
+    except IndexError:
+        pass
+
+
 def new_excepthook(etype, value, traceback):
     if etype == KeyboardInterrupt:
         pdebug("Interrupted by user...")
@@ -681,7 +695,7 @@ for i, h in enumerate(hosts):
 pdebug("All hosts: %s" % ",".join(hosts))
 
 
-json_out=[]
+json_out = []
 for host in hosts:
     pdebug("Scanning %s" % host)
     for test in tests:


### PR DESCRIPTION
I singled out the wordpress test from the previous Pull request. You can test it e.g. with the newsroom blog of a mobile provider from Austria.

I noted that `pycodestyle --ignore=E501 snallygaster` reports problems for lines 406-408 and 528, 529, 540-542 but my changes do not affect anything above line 600. 
It seems that `pycodestyle` detects  different issues depending on the installed version. With 2.3.1 (default on Ubuntu 17.10, and via `brew` on  MacOS) I get no error messages, and with 2.4.0 (release date 2018-04-10) the output changes to

```
snallygaster:405:8: W504 line break after binary operator
snallygaster:406:8: W504 line break after binary operator
snallygaster:407:8: W504 line break after binary operator
snallygaster:408:8: W504 line break after binary operator
snallygaster:528:8: W504 line break after binary operator
snallygaster:529:8: W504 line break after binary operator
snallygaster:540:16: W504 line break after binary operator
snallygaster:541:16: W504 line break after binary operator
snallygaster:542:16: W504 line break after binary operator
```
