### PR TITLE
Add test for common backup archive files

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -123,6 +123,12 @@ EMACS creates #[filename]#.
 All of these are particularly problematic in combination with PHP, as a file that may contain
 secrets will end up on the webspace without a .php extension and thus won't be parsed.
 
+backup_archives
+---------------
+
+Complete or partial backups of servers are sometimes left online. This test checks for common names
+like backup.tar.gz or [hostname].tar.gz.
+
 
 deadjoe
 -------

--- a/snallygaster
+++ b/snallygaster
@@ -339,11 +339,13 @@ def test_backupfiles(url):
 
 @DEFAULT
 def test_backup_archives(url):
-    for fn in ['backup.zip', 'www.zip', 'wwwroot.zip']:
+    domain = urllib.parse.urlparse(url).hostname
+    hostname = domain.split('.')[0]
+    for fn in ['backup.zip', 'www.zip', 'wwwroot.zip', hostname + '.zip', domain + '.zip']:
         r = fetchpartial(url + "/" + fn, 3, binary=True)
         if r == b'PK\x03':
             pout("backup_archives", url + "/" + fn)
-    for fn in ['backup.tar.gz', 'www.tar.gz', 'wwwroot.tar.gz']:
+    for fn in ['backup.tar.gz', 'www.tar.gz', hostname + '.tar.gz', domain + 'tar.gz']:
         r = fetchpartial(url + "/" + fn, 3, binary=True)
         if r == b'\x1f\x8b\x08':
             pout("backup_archives", url + "/" + fn)

--- a/snallygaster
+++ b/snallygaster
@@ -338,6 +338,18 @@ def test_backupfiles(url):
 
 
 @DEFAULT
+def test_backup_archives(url):
+    for fn in ['backup.zip', 'www.zip', 'wwwroot.zip']:
+        r = fetchpartial(url + "/" + fn, 3, binary=True)
+        if r == b'PK\x03':
+            pout("backup_archives", url + "/" + fn)
+    for fn in ['backup.tar.gz', 'www.tar.gz', 'wwwroot.tar.gz']:
+        r = fetchpartial(url + "/" + fn, 3, binary=True)
+        if r == b'\x1f\x8b\x08':
+            pout("backup_archives", url + "/" + fn)
+
+
+@DEFAULT
 def test_deadjoe(url):
     r = fetcher(url + '/DEADJOE')
     if 'in JOE when it aborted' in r:


### PR DESCRIPTION
This pull request adds a simple check for common backup archive files. The list of files consists of `backup.zip`, `www.zip`, `wwwroot.zip`, `backup.tar.gz`, `www.tar.gz` and `wwwroot.tar.gz` (the file names were inspired by https://github.com/unamer/CTFHelper/blob/master/CTFhelper.py#L82). 
Even though these files do not exist very often (approx. 0.1% of the checked hostnames), the security implications of a found backup are huge. A backup archive does not only contain source code which provides an insight into the site structure but it may also contain secret keys, database passwords or database dumps. Additionally, the test is inexpensive requiring only six HTTP requests.