### PR TITLE
Test: phpinfo

### DIFF
--- a/snallygaster
+++ b/snallygaster
@@ -634,6 +634,14 @@ def test_wordpress(url):
         return
 
 
+@INFO
+def test_phpinfo(url):
+    for fn in ["phpinfo.php", "info.php", "i.php", "test.php"]:
+        r = fetcher(url + "/" + fn)
+        if 'phpinfo()' in r:
+            pout("phpinfo", url + "/" + fn)
+            
+
 def new_excepthook(etype, value, traceback):
     if etype == KeyboardInterrupt:
         pdebug("Interrupted by user...")

--- a/snallygaster
+++ b/snallygaster
@@ -640,7 +640,7 @@ def test_phpinfo(url):
         r = fetcher(url + "/" + fn)
         if 'phpinfo()' in r:
             pout("phpinfo", url + "/" + fn)
-            
+
 
 def new_excepthook(etype, value, traceback):
     if etype == KeyboardInterrupt:


### PR DESCRIPTION
Many PHP web developers left the file with phpinfo() function accessible in root folder - phpinfo.php, info.php, i.php or test.php are the most common filenames for it. I saw other names with different cases, phpversion.php, x.php, a.php or index.php with some parameters, but I think the first four are the most used.