### PR TITLE
add check for RCS files (/RCS/*,v)

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -62,6 +62,12 @@ cvs_dir
 Identical to git_dir issue, just with CVS instead of Git.
 
 
+rcs_dir
+-------
+
+Similar to cvs_dir issue, but with RCS, the simpler VCS that is used by CVS (but can also be standalone).
+
+
 apache_server_status
 --------------------
 

--- a/snallygaster
+++ b/snallygaster
@@ -270,7 +270,6 @@ def test_cvs_dir(url):
 @DEFAULT
 def test_rcs_dir(url):
     r = fetcher(url + '/RCS/')
-    print(r)
     if ',v' in r:
         pout("rcs_dir", url + "/RCS")
 

--- a/snallygaster
+++ b/snallygaster
@@ -272,7 +272,6 @@ def test_rcs_dir(url):
     r = fetcher(url + '/RCS/')
     print(r)
     if ',v' in r:
-        print(r)
         pout("rcs_dir", url + "/RCS")
 
 @DEFAULT

--- a/snallygaster
+++ b/snallygaster
@@ -267,6 +267,13 @@ def test_cvs_dir(url):
     if len(r.split("\n")) == 2 and ':' in r and '<' not in r:
         pout("cvs_dir", url + "/CVS/Root")
 
+@DEFAULT
+def test_rcs_dir(url):
+    r = fetcher(url + '/RCS/')
+    print(r)
+    if ',v' in r:
+        print(r)
+        pout("rcs_dir", url + "/RCS")
 
 @DEFAULT
 def test_apache_server_status(url):


### PR DESCRIPTION
This adds a simple check for ,v files in the RCS directory. If the RCS directory is not exposed, or if no ,v files are shown, the test should pass.