### PR TITLE
replace deprecated ssl.wrap_socket with SSLContext

### DIFF
--- a/tests/test_scan_testdata.py
+++ b/tests/test_scan_testdata.py
@@ -35,7 +35,9 @@ class TestScanTestdata(unittest.TestCase):
         olddir = os.getcwd()
         os.chdir(tmp + "/testdata")
         httpd = http.server.HTTPServer(('localhost', 4443), http.server.SimpleHTTPRequestHandler)
-        httpd.socket = ssl.wrap_socket(httpd.socket, certfile=tmp + '/testdata/testserver.pem')
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.load_cert_chain(certfile=tmp + '/testdata/testserver.pem')
+        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
         t = threading.Thread(target=httpd.serve_forever)
         t.daemon = True
         t.start()


### PR DESCRIPTION
fixes hannob/snallygaster#57