### PR TITLE
add missing @INFO in front of test_phpinfo()

### DIFF
--- a/snallygaster
+++ b/snallygaster
@@ -916,6 +916,7 @@ def test_composer(url):
             pout("composer", furl)
 
 
+@INFO
 def test_phpinfo(url):
     for fn in ["phpinfo.php", "info.php", "i.php", "test.php"]:
         r = fetcher(url + "/" + fn)


### PR DESCRIPTION
add missing @INFO in front of test_phpinfo() as this test is declared in TESTS.md within the info-category.