### PR TITLE
Fix crash due to bad DNS on target

### DIFF
--- a/snallygaster
+++ b/snallygaster
@@ -803,7 +803,7 @@ def test_axfr(qhost):
             else:  # dnspython before 2.0
                 ipv4 = dns.resolver.query(r, 'a').rrset
                 ipv6 = dns.resolver.query(r, 'aaaa').rrset
-        except dns.resolver.NoAnswer:
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             pass
         ips = []
         for ip in ipv4:


### PR DESCRIPTION
snallygaster fails and stop execution with `dns.resolver.NXDOMAIN: The DNS query name does not exist: XXX.XX.XXX.XX.` if the IP address (masked as XX..) found does not resolve. This can be due to bad configuration from remote site and snallygaster should not fail but continue with other tasks.