### PR TITLE
Fix crash due to DNS timeout

### DIFF
--- a/snallygaster
+++ b/snallygaster
@@ -803,7 +803,8 @@ def test_axfr(qhost):
             else:  # dnspython before 2.0
                 ipv4 = dns.resolver.query(r, 'a').rrset
                 ipv6 = dns.resolver.query(r, 'aaaa').rrset
-        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN,
+                dns.resolver.LifetimeTimeout):
             pass
         ips = []
         for ip in ipv4:


### PR DESCRIPTION
Fixes crash due to `dns.resolver.LifetimeTimeout: The resolution lifetime expired after 19.275 seconds`.

snallygaster crashes during axfr test if the DNS server of the target responds slowly.
It should not crash completely but instead pass the test as desired behavior.

During crash, snallygaster logs to stderr the following:

```txt
Traceback (most recent call last):
  File "/tools/snallygaster/bin/snallygaster", line 1022, in <module>
    test(host)
  File "/tools/snallygaster/bin/snallygaster", line 801, in test_axfr
    ipv4 = dns.resolver.resolve(r, 'a').rrset
  File "/tools/snallygaster/lib/python3.10/site-packages/dns/resolver.py", line 1193, in resolve
    return get_default_resolver().resolve(qname, rdtype, rdclass, tcp, source,
  File "/tools/snallygaster/lib/python3.10/site-packages/dns/resolver.py", line 1066, in resolve
    timeout = self._compute_timeout(start, lifetime,
  File "/tools/snallygaster/lib/python3.10/site-packages/dns/resolver.py", line 879, in _compute_timeout
    raise LifetimeTimeout(timeout=duration, errors=errors)
dns.resolver.LifetimeTimeout: The resolution lifetime expired after 19.275 seconds: 
```

And stdout to:

```txt
Oh oh... an unhandled exception has happened. This shouldn't be.
Please report a bug and include all output.
```