### PR TITLE
Pin GitHub Actions to specific commits for security

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         python-version: [3.7,3.x,3.12-dev]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
For proof that GitHub Dependabot can still keep things up to date for us with the new format see https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .

Also addresses the issues pointed out at https://github.com/hannob/snallygaster/actions/runs/4584066882
![warn_snally_Screenshot_20230418_033218](https://user-images.githubusercontent.com/1577132/232646483-1899b322-e111-4e26-9018-2c491db53f20.png)

