### PR TITLE
runtests.yml: Ignore failures from Python version "3.12-dev"

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -6,9 +6,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
       matrix:
-        python-version: [3.7,3.x,3.12-dev]
+        python-version: [3.7, 3.x]
+        continue-on-error: [false]
+        include:
+        - python-version: 3.12-dev
+          continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
For proof of the effect see https://github.com/hartwork/snallygaster/actions/runs/4727528886 . I'm not 100% sure though how "complete" the effect will be after merging, e.g. this very pull request is marked as red while the related action is green :thinking: 

![snally_Screenshot_20230418_032556](https://user-images.githubusercontent.com/1577132/232645570-66981211-fd07-4edf-b66a-2f98dcc0ab28.png)
