### PR TITLE
Require beautifulsoup4 >= 4.11.0 for XMLParsedAsHTMLWarning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     packages=[],
     scripts=["snallygaster"],
     python_requires=">=3.7",
-    install_requires=["urllib3", "beautifulsoup4", "dnspython"],
+    install_requires=["urllib3", "beautifulsoup4>=4.11.0", "dnspython"],
     license="0BSD",
     zip_safe=True,
     keywords=["security", "vulnerability", "http"],


### PR DESCRIPTION
https://github.com/hannob/snallygaster/commit/73dab7cd26977bf43be37b37382a70edddb62f1f introduces dependency `bs4.builder.XMLParsedAsHTMLWarning`

That is only available since version 4.11.0 according to the changelog of beautifulsoup:

> = 4.11.0 (20220407)
> ...
> * Issue a warning when an HTML parser is used to parse a document that
>  looks like XML but not XHTML. [bug=1939121]